### PR TITLE
Add optional httpclient argument to HalHttpClientFactory

### DIFF
--- a/HalClient.Net.Tests/HalHttpClientFactoryTests.cs
+++ b/HalClient.Net.Tests/HalHttpClientFactoryTests.cs
@@ -1,4 +1,5 @@
-﻿using HalClient.Net.Parser;
+﻿using System.Net.Http;
+using HalClient.Net.Parser;
 using Xunit;
 
 namespace HalClient.Net.Tests
@@ -11,6 +12,16 @@ namespace HalClient.Net.Tests
         public void CreateClient_CreatesAClient()
         {
             using (var client = _target.CreateClient())
+            {
+                Assert.NotNull(client);
+            }
+        }
+
+        [Fact]
+        public void CreateClient_WithHttpClient()
+        {
+            using (var httpClient = new HttpClient())
+            using (var client = _target.CreateClient(httpClient))
             {
                 Assert.NotNull(client);
             }

--- a/HalClient.Net/HalHttpClient.cs
+++ b/HalClient.Net/HalHttpClient.cs
@@ -12,11 +12,11 @@ namespace HalClient.Net
         private readonly IHalJsonParser _parser;
         private HttpClient _client;
 
-        internal HalHttpClient(IHalJsonParser parser)
+        internal HalHttpClient(IHalJsonParser parser, HttpClient client)
         {
             if (parser == null) throw new ArgumentNullException("parser");
             _parser = parser;
-            _client = new HttpClient(new HttpClientHandler {AllowAutoRedirect = false});
+            _client = client ?? new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
         }
 
         public Uri BaseAddress

--- a/HalClient.Net/HalHttpClientFactory.cs
+++ b/HalClient.Net/HalHttpClientFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using HalClient.Net.Parser;
 
@@ -23,9 +24,9 @@ namespace HalClient.Net
             // Do nothing by default ...
         }
 
-        public IHalHttpClient CreateClient()
+        public IHalHttpClient CreateClient(HttpClient httpClient)
         {
-            return CreateHalHttpClient();
+            return CreateHalHttpClient(httpClient);
         }
 
         public IHalHttpClientWithRoot CreateClientWithRoot(bool refresh = false)
@@ -70,9 +71,9 @@ namespace HalClient.Net
             }
         }
 
-        private HalHttpClient CreateHalHttpClient()
+        private HalHttpClient CreateHalHttpClient(HttpClient httpClient = null)
         {
-            var client = new HalHttpClient(_parser);
+            var client = new HalHttpClient(_parser, httpClient);
 
             try
             {

--- a/HalClient.Net/IHalHttpClientFactory.cs
+++ b/HalClient.Net/IHalHttpClientFactory.cs
@@ -1,7 +1,9 @@
-﻿namespace HalClient.Net
+﻿using System.Net.Http;
+
+namespace HalClient.Net
 {
     public interface IHalHttpClientFactory
     {
-        IHalHttpClient CreateClient();
+        IHalHttpClient CreateClient(HttpClient httpClient = null);
     }
 }


### PR DESCRIPTION
In this way, HalClient can be used with Owin Testserver in this manner:

```
    [Fact]
    public async Task UseHalClientWithOwinTestServer()
    {
        var factory = new HalHttpClientFactory(new HalJsonParser());

        using (var server = Microsoft.Owin.Testing.TestServer.Create<Startup>())
        using (var client = factory.CreateClient(server.HttpClient))
        {
            var customers = await client.GetAsync(new Uri("http://mytestserver/customers/7809"));
        }
    }
```
