### PR TITLE
Allow _embedded to be null and not fail the parse.

### DIFF
--- a/HalClient.Net/Parser/HalJsonParser.cs
+++ b/HalClient.Net/Parser/HalJsonParser.cs
@@ -70,9 +70,12 @@ namespace HalClient.Net.Parser
 					switch (inner.Name)
 					{
 						case "_links":
-							throw new FormatException("Invalid value for _links: " + value);
 						case "_embedded":
-							throw new FormatException("Invalid value for _embedded: " + value);
+							if (inner.Value.Type != JTokenType.Null)
+							{
+								throw new FormatException(string.Format("Invalid value for {0}: {1}", inner.Name, value));
+							}
+							break;
 						default:
 							state.Add(new StateValue(inner.Name, value, type));
 							break;


### PR DESCRIPTION
This happens if there server is using:

JsonFormatter.SerializerSettings.NullValueHandling = NullValueHandling.Include
