### PR TITLE
Add custom attributes to hal links

### DIFF
--- a/HalClient.Net.Tests/HalJsonParserTests.cs
+++ b/HalClient.Net.Tests/HalJsonParserTests.cs
@@ -103,8 +103,23 @@ namespace HalClient.Net.Tests
 		}]
 	}
 }";
+        private const string JsonCustomLinkAttributes = @"
+{
+	""_links"": {
+		""self"": { ""href"": ""/orders"" },
+        ""home"": { 
+            ""href"": ""/home"", 
+            ""tags"": [""bookmark"", ""info""],
+            ""other"": ""test""
+        },
+		""curies"": [{ ""name"": ""ea"", ""href"": ""http://example.com/docs/rels/{rel}"", ""templated"": true }],
+	},
+	""currentlyProcessing"": 14,
+	""shippedToday"": 20,
+	""_embedded"": null
+}";
 
-		private readonly HalJsonParser _sut = new HalJsonParser();
+        private readonly HalJsonParser _sut = new HalJsonParser();
 
 		[Fact]
 		public void EmbeddedParsing_ParsesTheCorrectNumberOfRels()
@@ -227,5 +242,16 @@ namespace HalClient.Net.Tests
 
 			Assert.Equal(2, result.EmbeddedResources.Count());
 		}
-	}
+
+        [Fact]
+        public void LinksParsing_ParsesLinksWithCustomAttributes()
+        {
+            var result = _sut.Parse(JsonCustomLinkAttributes);
+
+            var homeLink = result.Links.Single(x => x.Rel == "home");
+
+            Assert.Equal(new[] { "bookmark", "info" }, homeLink.CustomAttributes["tags"]);
+            Assert.Equal("test", homeLink.CustomAttributes["other"]);
+        }
+    }
 }

--- a/HalClient.Net/HalClient.Net.csproj
+++ b/HalClient.Net/HalClient.Net.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Parser\EmbeddedResourceObject.cs" />
     <Compile Include="Parser\HalJsonParseResult.cs" />
     <Compile Include="Parser\IEmbeddedResourceObject.cs" />
+    <Compile Include="Parser\IHaveCustomAttributes.cs" />
     <Compile Include="Parser\ILinkObject.cs" />
     <Compile Include="Parser\IResourceObject.cs" />
     <Compile Include="Parser\IRootResourceObject.cs" />

--- a/HalClient.Net/Parser/IHaveCustomAttributes.cs
+++ b/HalClient.Net/Parser/IHaveCustomAttributes.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace HalClient.Net.Parser
+{
+    public interface IHaveCustomAttributes
+    {
+        IDictionary<string, object> CustomAttributes { get; }
+    }
+}

--- a/HalClient.Net/Parser/ILinkObject.cs
+++ b/HalClient.Net/Parser/ILinkObject.cs
@@ -3,7 +3,7 @@ using Tavis.UriTemplates;
 
 namespace HalClient.Net.Parser
 {
-	public interface ILinkObject : IHaveLinkRelation
+	public interface ILinkObject : IHaveLinkRelation, IHaveCustomAttributes
 	{
 		Uri Href { get; }
 		bool Templated { get; }

--- a/HalClient.Net/Parser/LinkObject.cs
+++ b/HalClient.Net/Parser/LinkObject.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Tavis.UriTemplates;
 
 namespace HalClient.Net.Parser
@@ -15,8 +16,10 @@ namespace HalClient.Net.Parser
 		public Uri Profile { get; private set; }
 		public string Title { get; set; }
 		public string HrefLang { get; set; }
-		
-		public ILinkObject ResolveTemplated(Func<UriTemplate, string> hrefResolver)
+	    public IDictionary<string, object> CustomAttributes { get; private set; } = new Dictionary<string, object>();
+
+
+        public ILinkObject ResolveTemplated(Func<UriTemplate, string> hrefResolver)
 		{
 			if (!Templated)
 				throw new InvalidOperationException("Cannot resolve a non-Templated link");
@@ -33,7 +36,8 @@ namespace HalClient.Net.Parser
 				Name = Name,
 				Profile = Profile,
 				Title = Title,
-				Type = Type
+				Type = Type,
+                CustomAttributes = CustomAttributes
 			};
 
 			link.SetHref(href);


### PR DESCRIPTION
We are using a super set of the HAL specification where we have extra attributes on links.
For example we want to indicate to the client whether or not a certain link can be bookmarked.

Currently the HalJsonParser throws an exception when it encounters an attribute it doesn't recognize.

Instead of throwing an exception the HalJsonParser could store these custom attributes (e.g. in a dictionary).
