### PR TITLE
No content no parsing

### DIFF
--- a/HalClient.Net.Tests/HalClient.Net.Tests.csproj
+++ b/HalClient.Net.Tests/HalClient.Net.Tests.csproj
@@ -33,8 +33,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Moq, Version=4.5.29.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.5.29\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/HalClient.Net.Tests/app.config
+++ b/HalClient.Net.Tests/app.config
@@ -5,7 +5,7 @@
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>

--- a/HalClient.Net.Tests/packages.config
+++ b/HalClient.Net.Tests/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
-	<package id="Moq" version="4.2.1510.2205" targetFramework="net451" />
-	<package id="xunit" version="2.1.0" targetFramework="net451" />
-	<package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
-	<package id="xunit.assert" version="2.1.0" targetFramework="net451" />
-	<package id="xunit.core" version="2.1.0" targetFramework="net451" />
-	<package id="xunit.extensibility.core" version="2.1.0" targetFramework="net451" />
-	<package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net451" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
+  <package id="Moq" version="4.5.29" targetFramework="net451" />
+  <package id="xunit" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net451" />
 </packages>

--- a/HalClient.Net/HalClient.Net.csproj
+++ b/HalClient.Net/HalClient.Net.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -45,7 +45,7 @@
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="Tavis.UriTemplates, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Tavis.UriTemplates.0.6.4\lib\Net45\Tavis.UriTemplates.dll</HintPath>
+      <HintPath>..\packages\Tavis.UriTemplates.1.1.0\lib\Net45\Tavis.UriTemplates.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/HalClient.Net/HalClient.Net.csproj
+++ b/HalClient.Net/HalClient.Net.csproj
@@ -44,11 +44,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
     <Reference Include="Tavis.UriTemplates, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Tavis.UriTemplates.0.6.4\lib\Net45\Tavis.UriTemplates.dll</HintPath>
       <Private>True</Private>
@@ -56,9 +51,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CachingBehavior.cs" />
+    <Compile Include="MediaType.cs" />
     <Compile Include="HalHttpClientFactory.cs" />
     <Compile Include="HalHttpClientConfiguration.cs" />
     <Compile Include="HalHttpRequestException.cs" />
+    <Compile Include="HalHttpResponseMessage.cs" />
+    <Compile Include="IHalHttpResponseMessage.cs" />
     <Compile Include="Parser\EmbeddedResourceObject.cs" />
     <Compile Include="Parser\HalJsonParseResult.cs" />
     <Compile Include="Parser\IEmbeddedResourceObject.cs" />

--- a/HalClient.Net/HalHttpClient.cs
+++ b/HalClient.Net/HalHttpClient.cs
@@ -121,7 +121,7 @@ namespace HalClient.Net
 
 			if (response.IsSuccessStatusCode)
 			{
-				if (response.StatusCode == HttpStatusCode.NoContent)
+				if ((response.StatusCode == HttpStatusCode.NoContent) || (response.StatusCode == HttpStatusCode.NotModified))
 					return new RootResourceObject();
 
 				if (string.IsNullOrEmpty(mediatype))

--- a/HalClient.Net/HalHttpClient.cs
+++ b/HalClient.Net/HalHttpClient.cs
@@ -92,7 +92,7 @@ namespace HalClient.Net
 				Configuration.Headers.Accept.Add(headerValue);
 		}
 
-		private MediaTypeWithQualityHeaderValue[] OverrideAcceptHeaders()
+		private IEnumerable<MediaTypeWithQualityHeaderValue> OverrideAcceptHeaders()
 		{
 			var backup = Configuration.Headers.Accept.ToArray();
 
@@ -112,10 +112,10 @@ namespace HalClient.Net
 
 			var message = await HalHttpResponseMessage.CreateAsync(response, _parser);
 
-			if (message.IsSuccessStatusCode)
+			if (response.IsSuccessStatusCode || !Configuration.ThrowOnError)
 				return message;
 
-			throw new HalHttpRequestException(message);
+			throw new HalHttpRequestException(response.StatusCode, response.ReasonPhrase, message.Resource);
 		}
 
 		public void Dispose()
@@ -134,6 +134,11 @@ namespace HalClient.Net
 
 			_httpClient.Dispose();
 			_httpClient = null;
+		}
+
+		~HalHttpClient()
+		{
+			Dispose(false);
 		}
 	}
 }

--- a/HalClient.Net/HalHttpClient.cs
+++ b/HalClient.Net/HalHttpClient.cs
@@ -11,7 +11,6 @@ namespace HalClient.Net
 {
 	internal class HalHttpClient : IHalHttpClient
 	{
-		private const string ApplicationHalJson = "application/hal+json";
 		private readonly IHalJsonParser _parser;
 		private HttpClient _httpClient;
 
@@ -31,7 +30,7 @@ namespace HalClient.Net
 
 		public IHalHttpClientConfiguration Configuration { get; }
 		
-		public async Task<IRootResourceObject> PostAsync<T>(Uri uri, T data)
+		public async Task<IHalHttpResponseMessage> PostAsync<T>(Uri uri, T data)
 		{
 			var backup = OverrideAcceptHeaders();
 			var response = await _httpClient.PostAsJsonAsync(uri, data);
@@ -41,7 +40,7 @@ namespace HalClient.Net
 			return await ProcessResponseMessage(response);
 		}
 
-		public async Task<IRootResourceObject> PutAsync<T>(Uri uri, T data)
+		public async Task<IHalHttpResponseMessage> PutAsync<T>(Uri uri, T data)
 		{
 			var backup = OverrideAcceptHeaders();
 			var response = await _httpClient.PutAsJsonAsync(uri, data);
@@ -51,7 +50,7 @@ namespace HalClient.Net
 			return await ProcessResponseMessage(response);
 		}
 
-		public async Task<IRootResourceObject> GetAsync(Uri uri)
+		public async Task<IHalHttpResponseMessage> GetAsync(Uri uri)
 		{
 			var backup = OverrideAcceptHeaders();
 			var response = await _httpClient.GetAsync(uri);
@@ -61,7 +60,7 @@ namespace HalClient.Net
 			return await ProcessResponseMessage(response);
 		}
 
-		public async Task<IRootResourceObject> DeleteAsync(Uri uri)
+		public async Task<IHalHttpResponseMessage> DeleteAsync(Uri uri)
 		{
 			var backup = OverrideAcceptHeaders();
 			var response = await _httpClient.DeleteAsync(uri);
@@ -71,7 +70,7 @@ namespace HalClient.Net
 			return await ProcessResponseMessage(response);
 		}
 
-		public async Task<IRootResourceObject> SendAsync(HttpRequestMessage request)
+		public async Task<IHalHttpResponseMessage> SendAsync(HttpRequestMessage request)
 		{
 			var backup = OverrideAcceptHeaders();
 			var response = await _httpClient.SendAsync(request);
@@ -98,55 +97,25 @@ namespace HalClient.Net
 			var backup = Configuration.Headers.Accept.ToArray();
 
 			Configuration.Headers.Accept.Clear();
-			Configuration.Headers.Add("Accept", ApplicationHalJson);
+			Configuration.Headers.Add("Accept", MediaType.ApplicationHalPlusJson);
 
 			return backup;
 		}
 
-		private async Task<IRootResourceObject> ProcessResponseMessage(HttpResponseMessage response)
+		private async Task<IHalHttpResponseMessage> ProcessResponseMessage(HttpResponseMessage response)
 		{
-			if ((response.StatusCode == HttpStatusCode.Redirect) ||
-				(response.StatusCode == HttpStatusCode.SeeOther) ||
-				(response.StatusCode == HttpStatusCode.RedirectMethod))
+			if (Configuration.AutoFollowRedirects &&
+			    ((response.StatusCode == HttpStatusCode.Redirect) ||
+			     (response.StatusCode == HttpStatusCode.SeeOther) ||
+			     (response.StatusCode == HttpStatusCode.RedirectMethod)))
 				return await GetAsync(response.Headers.Location);
 
-			string mediatype = null;
-			var isHalResponse = false;
+			var message = await HalHttpResponseMessage.CreateAsync(response, _parser);
 
-			if (response.Content.Headers.ContentType != null)
-			{
-				mediatype = response.Content.Headers.ContentType.MediaType;
-				isHalResponse = mediatype.Equals(ApplicationHalJson, StringComparison.OrdinalIgnoreCase);
-			}
+			if (message.IsSuccessStatusCode)
+				return message;
 
-			if (response.IsSuccessStatusCode)
-			{
-				if ((response.StatusCode == HttpStatusCode.NoContent) || (response.StatusCode == HttpStatusCode.NotModified))
-					return new RootResourceObject();
-
-				if (string.IsNullOrEmpty(mediatype))
-					throw new NotSupportedException("The response is missing the 'Content-Type' header");
-
-				if (!isHalResponse)
-					throw new NotSupportedException("The response contains an unsupported 'Content-Type' header value: " + mediatype);
-
-				return await ParseContentAsync(response);
-			}
-
-			if (!isHalResponse)
-				throw new HalHttpRequestException(response.StatusCode, response.ReasonPhrase);
-
-			var resource = await ParseContentAsync(response);
-
-			throw new HalHttpRequestException(response.StatusCode, response.ReasonPhrase, resource);
-		}
-
-		private async Task<IRootResourceObject> ParseContentAsync(HttpResponseMessage response)
-		{
-			var json = await response.Content.ReadAsStringAsync();
-			var result = _parser.Parse(json);
-
-			return new RootResourceObject(result);
+			throw new HalHttpRequestException(message);
 		}
 
 		public void Dispose()

--- a/HalClient.Net/HalHttpClientConfiguration.cs
+++ b/HalClient.Net/HalHttpClientConfiguration.cs
@@ -11,6 +11,7 @@ namespace HalClient.Net
 		public HalHttpClientConfiguration(HttpClient httpClient)
 		{
 			_httpClient = httpClient;
+			AutoFollowRedirects = true;
 		}
 
 		public Uri BaseAddress
@@ -30,6 +31,8 @@ namespace HalClient.Net
 			get { return _httpClient.Timeout; }
 			set { _httpClient.Timeout = value; }
 		}
+
+		public bool AutoFollowRedirects { get; set; }
 
 		public HttpRequestHeaders Headers => _httpClient.DefaultRequestHeaders;
 	}

--- a/HalClient.Net/HalHttpClientConfiguration.cs
+++ b/HalClient.Net/HalHttpClientConfiguration.cs
@@ -12,6 +12,7 @@ namespace HalClient.Net
 		{
 			_httpClient = httpClient;
 			AutoFollowRedirects = true;
+			ThrowOnError = true;
 		}
 
 		public Uri BaseAddress
@@ -33,6 +34,7 @@ namespace HalClient.Net
 		}
 
 		public bool AutoFollowRedirects { get; set; }
+		public bool ThrowOnError { get; set; }
 
 		public HttpRequestHeaders Headers => _httpClient.DefaultRequestHeaders;
 	}

--- a/HalClient.Net/HalHttpClientFactory.cs
+++ b/HalClient.Net/HalHttpClientFactory.cs
@@ -44,7 +44,9 @@ namespace HalClient.Net
 			if (config.BaseAddress == null)
 				throw new InvalidOperationException("The root resource can only be requested for caching if the BaseAddress of the client is initialized in the Configure method of the factory.");
 
-			return await client.GetAsync(config.BaseAddress).ConfigureAwait(false);
+			var message = await client.GetAsync(config.BaseAddress).ConfigureAwait(false);
+
+			return message.Resource;
 		}
 
 		public IHalHttpClient CreateClient()

--- a/HalClient.Net/HalHttpRequestException.cs
+++ b/HalClient.Net/HalHttpRequestException.cs
@@ -1,18 +1,19 @@
 using System;
+using System.Net;
+using HalClient.Net.Parser;
 
 namespace HalClient.Net
 {
 	[Serializable]
 	public class HalHttpRequestException : Exception
 	{
-		public HalHttpRequestException(IHalHttpResponseMessage message) : base(message.ReasonPhrase)
+		public HalHttpRequestException(HttpStatusCode statusCode, string reason, IRootResourceObject resource = null)
+			: base($"{(int)statusCode} ({reason})")
 		{
-			if (message == null)
-				throw new ArgumentNullException(nameof(message));
-
-			ResponseMessage = message;
+			StatusCode = statusCode;
+			Resource = resource;
 		}
-
-		public IHalHttpResponseMessage ResponseMessage { get; }
+		public HttpStatusCode StatusCode { get; }
+		public IRootResourceObject Resource { get; }
 	}
 }

--- a/HalClient.Net/HalHttpRequestException.cs
+++ b/HalClient.Net/HalHttpRequestException.cs
@@ -1,20 +1,18 @@
 using System;
-using System.Net;
-using HalClient.Net.Parser;
 
 namespace HalClient.Net
 {
 	[Serializable]
 	public class HalHttpRequestException : Exception
 	{
-		public HalHttpRequestException(HttpStatusCode statusCode, string reason, IRootResourceObject resource = null) 
-			: base($"{(int)statusCode} ({reason})")
+		public HalHttpRequestException(IHalHttpResponseMessage message) : base(message.ReasonPhrase)
 		{
-			StatusCode = statusCode;
-			Resource = resource;
+			if (message == null)
+				throw new ArgumentNullException(nameof(message));
+
+			ResponseMessage = message;
 		}
 
-		public HttpStatusCode StatusCode { get; }
-		public IRootResourceObject Resource { get; }
+		public IHalHttpResponseMessage ResponseMessage { get; }
 	}
 }

--- a/HalClient.Net/HalHttpResponseMessage.cs
+++ b/HalClient.Net/HalHttpResponseMessage.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using HalClient.Net.Parser;
+
+namespace HalClient.Net
+{
+	internal class HalHttpResponseMessage : IHalHttpResponseMessage
+	{
+		private HalHttpResponseMessage(HttpResponseMessage response)
+		{
+			StatusCode = response.StatusCode;
+			Location = response.Headers.Location;
+			IsSuccessStatusCode = response.IsSuccessStatusCode;
+			ReasonPhrase = response.ReasonPhrase;
+
+			if (response.Content.Headers.ContentType == null)
+				return;
+
+			Mediatype = response.Content.Headers.ContentType.MediaType;
+			IsHalResponse = Mediatype.Equals(MediaType.ApplicationHalPlusJson, StringComparison.OrdinalIgnoreCase);
+		}
+
+		public string ReasonPhrase { get; }
+		public bool IsSuccessStatusCode { get; }
+		public Uri Location { get; }
+		public HttpStatusCode StatusCode { get; }
+		public string Mediatype { get; }
+		public bool IsHalResponse { get; }
+		public string Content { get; private set; }
+		public IRootResourceObject Resource { get; private set; }
+
+		public static async Task<IHalHttpResponseMessage> CreateAsync(HttpResponseMessage response, IHalJsonParser parser)
+		{
+			if (response == null)
+				throw new ArgumentNullException(nameof(response));
+
+			if (parser == null)
+				throw new ArgumentNullException(nameof(parser));
+
+			var message = new HalHttpResponseMessage(response)
+			{
+				Content = await response.Content.ReadAsStringAsync()
+			};
+
+			if (message.IsHalResponse)
+			{
+				var result = parser.Parse(message.Content);
+				message.Resource = new RootResourceObject(result);
+			}
+
+			return message;
+		}
+	}
+}

--- a/HalClient.Net/HalHttpResponseMessage.cs
+++ b/HalClient.Net/HalHttpResponseMessage.cs
@@ -17,7 +17,6 @@ namespace HalClient.Net
 			var mediaType = response.Content.Headers.ContentType.MediaType;
 
 			IsHalResponse = mediaType.Equals(MediaType.ApplicationHalPlusJson, StringComparison.OrdinalIgnoreCase);
-			Resource = new RootResourceObject();
 		}
 
 		public HttpResponseMessage Message { get; private set; }
@@ -43,6 +42,10 @@ namespace HalClient.Net
 					var result = parser.Parse(content);
 
 					message.Resource = new RootResourceObject(result);
+				}
+				else
+				{
+					message.Resource = new RootResourceObject();
 				}
 			}
 

--- a/HalClient.Net/IHalHttpClient.cs
+++ b/HalClient.Net/IHalHttpClient.cs
@@ -7,11 +7,11 @@ namespace HalClient.Net
 {
 	public interface IHalHttpClient : IDisposable
 	{
-		Task<IRootResourceObject> PostAsync<T>(Uri uri, T data);
-		Task<IRootResourceObject> PutAsync<T>(Uri uri, T data);
-		Task<IRootResourceObject> GetAsync(Uri uri);
-		Task<IRootResourceObject> DeleteAsync(Uri uri);
-		Task<IRootResourceObject> SendAsync(HttpRequestMessage request);
+		Task<IHalHttpResponseMessage> PostAsync<T>(Uri uri, T data);
+		Task<IHalHttpResponseMessage> PutAsync<T>(Uri uri, T data);
+		Task<IHalHttpResponseMessage> GetAsync(Uri uri);
+		Task<IHalHttpResponseMessage> DeleteAsync(Uri uri);
+		Task<IHalHttpResponseMessage> SendAsync(HttpRequestMessage request);
 		IRootResourceObject CachedApiRootResource { get; }
 		HttpClient HttpClient { get; }
 	}

--- a/HalClient.Net/IHalHttpClientConfiguration.cs
+++ b/HalClient.Net/IHalHttpClientConfiguration.cs
@@ -9,5 +9,6 @@ namespace HalClient.Net
 		long MaxResponseContentBufferSize { get; set; }
 		TimeSpan Timeout { get; set; }
 		HttpRequestHeaders Headers { get; }
+		bool AutoFollowRedirects { get; set; }
 	}
 }

--- a/HalClient.Net/IHalHttpClientConfiguration.cs
+++ b/HalClient.Net/IHalHttpClientConfiguration.cs
@@ -1,14 +1,41 @@
 using System;
+using System.Net.Http;
 using System.Net.Http.Headers;
 
 namespace HalClient.Net
 {
 	public interface IHalHttpClientConfiguration
 	{
+		/// <summary>
+		/// <see cref="HttpClient.BaseAddress"/>
+		/// </summary>
 		Uri BaseAddress { get; set; }
+
+		/// <summary>
+		/// <see cref="HttpClient.MaxResponseContentBufferSize"/>
+		/// </summary>
 		long MaxResponseContentBufferSize { get; set; }
+
+		/// <summary>
+		/// <see cref="HttpClient.Timeout"/>
+		/// </summary>
 		TimeSpan Timeout { get; set; }
+
+		/// <summary>
+		/// <see cref="HttpClient.DefaultRequestHeaders"/>
+		/// </summary>
 		HttpRequestHeaders Headers { get; }
+
+		/// <summary>
+		/// Wether the client should automatically follow (ie. perform a subsequent GET request) in case the server returns either an HTTP 302 or 303 status code.
+		/// Default value is true.
+		/// </summary>
 		bool AutoFollowRedirects { get; set; }
+
+		/// <summary>
+		/// Wether a <see cref="HalHttpRequestException"/> should be thrown upon receiving a non-success response from the server.
+		/// Default value is true.
+		/// </summary>
+		bool ThrowOnError { get; set; }
 	}
 }

--- a/HalClient.Net/IHalHttpResponseMessage.cs
+++ b/HalClient.Net/IHalHttpResponseMessage.cs
@@ -1,18 +1,12 @@
-using System;
-using System.Net;
+using System.Net.Http;
 using HalClient.Net.Parser;
 
 namespace HalClient.Net
 {
 	public interface IHalHttpResponseMessage
 	{
-		string ReasonPhrase { get; }
-		bool IsSuccessStatusCode { get; }
-		Uri Location { get; }
-		HttpStatusCode StatusCode { get; }
-		string Mediatype { get; }
+		HttpResponseMessage Message { get; }
 		bool IsHalResponse { get; }
-		string Content { get; }
 		IRootResourceObject Resource { get; }
 	}
 }

--- a/HalClient.Net/IHalHttpResponseMessage.cs
+++ b/HalClient.Net/IHalHttpResponseMessage.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Net;
+using HalClient.Net.Parser;
+
+namespace HalClient.Net
+{
+	public interface IHalHttpResponseMessage
+	{
+		string ReasonPhrase { get; }
+		bool IsSuccessStatusCode { get; }
+		Uri Location { get; }
+		HttpStatusCode StatusCode { get; }
+		string Mediatype { get; }
+		bool IsHalResponse { get; }
+		string Content { get; }
+		IRootResourceObject Resource { get; }
+	}
+}

--- a/HalClient.Net/MediaType.cs
+++ b/HalClient.Net/MediaType.cs
@@ -1,0 +1,7 @@
+namespace HalClient.Net
+{
+	internal static class MediaType
+	{
+		public const string ApplicationHalPlusJson = "application/hal+json";
+	}
+}

--- a/HalClient.Net/Properties/AssemblyInfo.cs
+++ b/HalClient.Net/Properties/AssemblyInfo.cs
@@ -8,5 +8,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright (C) Geoffrey Braaf, WIS3GUY.NET")]
 [assembly: ComVisible(false)]
 [assembly: Guid("cca82297-341f-4b5f-a0fe-e650b25b72eb")]
-[assembly: AssemblyVersion("1.3.0.*")]
-[assembly: AssemblyInformationalVersion("1.3.0")]
+[assembly: AssemblyVersion("2.0.0.*")]
+[assembly: AssemblyInformationalVersion("2.0.0")]

--- a/HalClient.Net/app.config
+++ b/HalClient.Net/app.config
@@ -5,7 +5,7 @@
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>

--- a/HalClient.Net/packages.config
+++ b/HalClient.Net/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
-	<package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
-	<package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
-	<package id="Tavis.UriTemplates" version="0.6.4" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="Tavis.UriTemplates" version="1.1.0" targetFramework="net451" />
 </packages>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -155,6 +155,8 @@ The following options can be configured:
 `MaxResponseContentBufferSize` | Exposes the `MaxResponseContentBufferSize` property of the underlying `HttpClient` instance.
 `Timeout` | Exposes the `Timeout ` property of the underlying `HttpClient` instance.
 `ApiRootResourceCachingBehavior ` | Tells the `HalHttpClientFactory` wether or not the API's root resource should be cached.
+`ThrowOnError` | Wether a `HalHttpRequestException` should be thrown upon receiving a non-success response from the server. The default value is true.
+`AutoFollowRedirects` | Wether the client should automatically follow (ie. perform a subsequent GET request) in case the server returns either an HTTP 302 or 303 status code. The default value is true.
 
 > Note that, whatever `Accept` header you configure, the value will be overridden and set to `application/hal+json` unless you communicate using the `IHalHttpClient.HttpClient`.
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -32,20 +32,26 @@ Within your code, you can now use the factory to create your clients as follows:
 ```c#
 using (var client = factory.CreateClient())
 {
-	var resource = await client.GetAsync(new Uri("http://example.com/orders"));
-
-	// get the self link of the root resource
-	var selfUri = resource.Links["self"].First().Href;
+	using(var response = await client.GetAsync(new Uri("http://example.com/orders")))
+	{
+		if (response.IsHalResponse)
+		{
+			// get the self link of the root resource
+			var selfUri = response.Resource.Links["self"].First().Href;
 	
-	// get the order dates of all embedded order resources
-	var orderDates = resource.Embedded["example:order"].Select(x => x.State["Date"].Value);
+			// get the order dates of all embedded order resources
+			var orderDates = response.Resource.Embedded["example:order"].Select(x => x.State["Date"].Value);
 	
-	// automatically resolve the documentation uri for a named link relation based on curies
-	var documentationUri = resource.GetDocumentationUri(resource.Links["address:invoice"].First());
+			// automatically resolve the documentation uri for a named link relation based on curies
+			var documentationUri = response.Resource.GetDocumentationUri(resource.Links["address:invoice"].First());
+		}
+	}
 }
 ```
 
-> Note that the client is disposable!
+> Note that both the client and the response are disposable!
+
+Depending on how you set the `ThrowOnError` (default value is `true)`flag in the configuration, be sure to check the `response.Message.IsSuccessStatusCode` before deciding what to do with the returned information.
 
 ###Working with `ILinkObject` instances
 After parsing the `application/hal+json` response from the API, the returned resource contains a dictionary of links as they were encounteres in the `_links` property of the resource. The key in this dictionary is the link's `rel`, the value of each pair in the dictionary, is an `IEnumerable<ILinkObject>`. The reason for this being an enumerable is that the response might contain multiple links with the same `rel` attribute.
@@ -166,7 +172,7 @@ public class CustomHalHttpClient : IHalHttpClient
 		_decorated = decorated;
 	}
 
-	public Task<IRootResourceObject> PostAsync<T>(Uri uri, T data)
+	public Task<IHalHttpResponseMessage> PostAsync<T>(Uri uri, T data)
 	{
 		//
 		// do something fancy with the uri and/or data
@@ -179,28 +185,28 @@ public class CustomHalHttpClient : IHalHttpClient
 		//
 	}
 
-	public Task<IRootResourceObject> PutAsync<T>(Uri uri, T data)
+	public Task<IHalHttpResponseMessage> PutAsync<T>(Uri uri, T data)
 	{
 		//
 		// Custom code might go here
 		//
 	}
 
-	public Task<IRootResourceObject> GetAsync(Uri uri)
+	public Task<IHalHttpResponseMessage> GetAsync(Uri uri)
 	{
 		//
 		// Custom code might go here
 		//
 	}
 
-	public Task<IRootResourceObject> DeleteAsync(Uri uri)
+	public Task<IHalHttpResponseMessage> DeleteAsync(Uri uri)
 	{
 		//
 		// Custom code might go here
 		//
 	}
 
-	public Task<IRootResourceObject> SendAsync(HttpRequestMessage request)
+	public Task<IHalHttpResponseMessage> SendAsync(HttpRequestMessage request)
 	{
 		//
 		// Custom code might go here


### PR DESCRIPTION
**IMPORTANT** This PR contains breaking changes, so a major version bump is required!

### Major
* Refactored the client so that it no longer throws an exception if the received response has no content. Only if there is content, will the client attempt to parse it.
* Refactored the client so that it returns `HalHttpResponseMessage` instances, rather than parsed `RootResourceObject` instances directly. The new message object allows the consuming code to access the `Location` header as well as status information.

### Minor
* Updated nuget packages
* Extended and updated documentation