### PR TITLE
Target .net standard 2.0 and add serialization ctor

### DIFF
--- a/HalClient.Net.Tests/HalClient.Net.Tests.csproj
+++ b/HalClient.Net.Tests/HalClient.Net.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project=".\..\HalClient.Net.Build\HalClient.Net.Commons.props" />
   
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFrameworks>netcoreapp1.1;net462</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/HalClient.Net/HalClient.Net.csproj
+++ b/HalClient.Net/HalClient.Net.csproj
@@ -3,7 +3,11 @@
   <Import Project=".\..\HalClient.Net.Build\HalClient.Net.Commons.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework) == 'netstandard2.0'">
+    <DefineConstants>REQUIRES_EXCEPTION_SERIALIZATION_CTOR</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HalClient.Net/HalHttpRequestException.cs
+++ b/HalClient.Net/HalHttpRequestException.cs
@@ -1,20 +1,27 @@
 using System;
 using System.Net;
+using System.Runtime.Serialization;
 using HalClient.Net.Parser;
 
 namespace HalClient.Net
 {
-	[Serializable]
-	public class HalHttpRequestException : Exception
-	{
-		public HalHttpRequestException(HttpStatusCode statusCode, string reason, IRootResourceObject resource = null)
-			: base($"{(int) statusCode} ({reason})")
-		{
-			StatusCode = statusCode;
-			Resource = resource;
-		}
+    [Serializable]
+    public class HalHttpRequestException : Exception
+    {
+#if REQUIRES_EXCEPTION_SERIALIZATION_CTOR
+        protected HalHttpRequestException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+#endif
 
-		public HttpStatusCode StatusCode { get; }
-		public IRootResourceObject Resource { get; }
-	}
+        public HalHttpRequestException(HttpStatusCode statusCode, string reason, IRootResourceObject resource = null)
+            : base($"{(int)statusCode} ({reason})")
+        {
+            StatusCode = statusCode;
+            Resource = resource;
+        }
+
+        public HttpStatusCode StatusCode { get; }
+        public IRootResourceObject Resource { get; }
+    }
 }


### PR DESCRIPTION
Forgive me for PR'ing you without discussing this issue first. 😄 

When the library is consumed from full .NET fx, and something tries to serialize `HalHttpRequestException`, it fails because the serialization ctor is missing.

The error looks like this:

```
Stacktrace: 
System.Runtime.Serialization.SerializationException: The constructor to deserialize an object of type 'HalClient.Net.HalHttpRequestException' was not found. ---> System.Runtime.Serialization.SerializationException: The constructor to deserialize an object of type 'HalClient.Net.HalHttpRequestException' was not found.
   at System.Runtime.Serialization.ObjectManager.GetConstructor(RuntimeType t)
   at System.Runtime.Serialization.ObjectManager.CompleteISerializableObject(Object obj, SerializationInfo info, StreamingContext context)
   --- End of inner exception stack trace ---

Server stack trace: 
   at System.Runtime.Serialization.ObjectManager.CompleteISerializableObject(Object obj, SerializationInfo info, StreamingContext context)
   at System.Runtime.Serialization.ObjectManager.FixupSpecialObject(ObjectHolder holder)
   at System.Runtime.Serialization.ObjectManager.DoFixups()
   at System.Runtime.Serialization.Formatters.Binary.ObjectReader.Deserialize(HeaderHandler handler, __BinaryParser serParser, Boolean fCheck, Boolean isCrossAppDomain, IMethodCallMessage methodCallMessage)
   at System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize(Stream serializationStream, HeaderHandler handler, Boolean fCheck, Boolean isCrossAppDomain, IMethodCallMessage methodCallMessage)
   at System.Runtime.Remoting.Channels.CoreChannel.DeserializeBinaryResponseMessage(Stream inputStream, IMethodCallMessage reqMsg, Boolean bStrictBinding)
   at System.Runtime.Remoting.Channels.BinaryClientFormatterSink.SyncProcessMessage(IMessage msg)

Exception rethrown at [0]: 
   at System.Runtime.Remoting.Proxies.RealProxy.HandleReturnMessage(IMessage reqMsg, IMessage retMsg)
   at System.Runtime.Remoting.Proxies.RealProxy.PrivateInvoke(MessageData& msgData, Int32 type)
   at (...my code...)

Inner Stacktrace: 
The constructor to deserialize an object of type 'HalClient.Net.HalHttpRequestException' was not found.
   at System.Runtime.Serialization.ObjectManager.GetConstructor(RuntimeType t)
   at System.Runtime.Serialization.ObjectManager.CompleteISerializableObject(Object obj, SerializationInfo info, StreamingContext context)The constructor to deserialize an object of type 'HalClient.Net.HalHttpRequestException' was not found.

Server stack trace: 
   at System.Runtime.Serialization.ObjectManager.CompleteISerializableObject(Object obj, SerializationInfo info, StreamingContext context)
   at System.Runtime.Serialization.ObjectManager.FixupSpecialObject(ObjectHolder holder)
   at System.Runtime.Serialization.ObjectManager.DoFixups()
   at System.Runtime.Serialization.Formatters.Binary.ObjectReader.Deserialize(HeaderHandler handler, __BinaryParser serParser, Boolean fCheck, Boolean isCrossAppDomain, IMethodCallMessage methodCallMessage)
   at System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.Deserialize(Stream serializationStream, HeaderHandler handler, Boolean fCheck, Boolean isCrossAppDomain, IMethodCallMessage methodCallMessage)
   at System.Runtime.Remoting.Channels.CoreChannel.DeserializeBinaryResponseMessage(Stream inputStream, IMethodCallMessage reqMsg, Boolean bStrictBinding)
   at System.Runtime.Remoting.Channels.BinaryClientFormatterSink.SyncProcessMessage(IMessage msg)

Exception rethrown at [0]: 
   at System.Runtime.Remoting.Proxies.RealProxy.HandleReturnMessage(IMessage reqMsg, IMessage retMsg)
   at System.Runtime.Remoting.Proxies.RealProxy.PrivateInvoke(MessageData& msgData, Int32 type)
   at (...my code...)
```

When defining exceptions, it is required that a ctor accepting `SerializationInfo` and `StreamingContext` be implemented for serialization to work.

This PR adds .NET Standard 2.0 as a target (in addition to .NET Standard 1.3), where the necessary `Exception` base ctor is available. A compilation symbol `REQUIRES_EXCEPTION_SERIALIZATION_CTOR` is introduced to make it possible for the code to only include the serialization ctor when targeting .NET Standard 2.0.