### PR TITLE
fixes #27

### DIFF
--- a/HalClient.Net.Tests/HalJsonParserTests.cs
+++ b/HalClient.Net.Tests/HalJsonParserTests.cs
@@ -227,5 +227,21 @@ namespace HalClient.Net.Tests
 
 			Assert.Equal(2, result.EmbeddedResources.Count());
 		}
+		
+		/// <summary>
+		/// See: https://github.com/wis3guy/HalClient.Net/issues/27
+		/// </summary>
+		[Fact]
+		public void StateParsing_LeavesDatesUntouched()
+		{
+			const string expected = "2019-04-22T20:52:50Z";
+			
+			var json = $"{{'date': '{expected}'}}";
+			var parser = new HalJsonParser();
+			var result = parser.Parse(json);
+			var date = result.StateValues.Single(sv => sv.Name == "date");
+
+			Assert.Equal(date.Value, expected);
+		}
 	}
 }

--- a/HalClient.Net/Parser/HalJsonParser.cs
+++ b/HalClient.Net/Parser/HalJsonParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -12,10 +13,14 @@ namespace HalClient.Net.Parser
 			if (string.IsNullOrEmpty(json))
 				throw new ArgumentNullException(nameof(json));
 
-			var obj = JObject.Parse(json);
-			var resource = ParseRootResourceObject(obj);
-
-			return resource;
+			using (var stringReader = new StringReader(json))
+			using (var jsonReader = new JsonTextReader(stringReader){ DateParseHandling = DateParseHandling.None })
+			{
+				var obj = JObject.Load(jsonReader);
+				var resource = ParseRootResourceObject(obj);
+				
+				return resource;	
+			}
 		}
 
 		private static HalJsonParseResult ParseRootResourceObject(JObject outer)


### PR DESCRIPTION
Changes the way dates are parsed by the `HalJsonParser`. 

As of now, dates (as interpreted by `Json.Net`) are placed in the state collection as-is, without any parsing and/or modification.